### PR TITLE
debian: Add mogwai-scheduled user in a postinst script

### DIFF
--- a/debian/mogwai-scheduled.postinst
+++ b/debian/mogwai-scheduled.postinst
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = configure ]; then
+    systemd-sysusers /lib/sysusers.d/mogwai-scheduled.conf
+fi
+
+#DEBHELPER#


### PR DESCRIPTION
Call systemd-sysusers to re-use the existing configuration.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T20422