### PR TITLE
misc: Clean up use of g_auto(GVariantDict)

### DIFF
--- a/libmogwai-schedule-client/schedule-entry.c
+++ b/libmogwai-schedule-client/schedule-entry.c
@@ -525,8 +525,7 @@ properties_changed_cb (GDBusProxy *proxy,
   MwscScheduleEntry *self = MWSC_SCHEDULE_ENTRY (user_data);
   g_autoptr(GError) error = NULL;
 
-  g_auto(GVariantDict) dict;
-  g_variant_dict_init (&dict, changed_properties);
+  g_auto(GVariantDict) dict = G_VARIANT_DICT_INIT (changed_properties);
 
   g_object_freeze_notify (G_OBJECT (self));
 

--- a/libmogwai-schedule/schedule-service.c
+++ b/libmogwai-schedule/schedule-service.c
@@ -447,9 +447,7 @@ entry_notify_cb (GObject    *obj,
   /* Propagate the signal as a D-Bus signal. Expect no errors, since the
    * documentation says this can only fail if the GVariant type is wrong. */
   const gchar *property_name = g_param_spec_get_name (pspec);
-  /* FIXME: Upstream this as G_VARIANT_DICT_INIT. */
-  g_auto(GVariantDict) changed_properties_dict;
-  g_variant_dict_init (&changed_properties_dict, NULL);
+  g_auto(GVariantDict) changed_properties_dict = G_VARIANT_DICT_INIT (NULL);
 
   if (g_str_equal (property_name, "priority"))
     g_variant_dict_insert (&changed_properties_dict,

--- a/mogwai-schedule-client/main.c
+++ b/mogwai-schedule-client/main.c
@@ -176,8 +176,7 @@ download_uri_async (const gchar         *uri,
   data->session = soup_session_new ();
 
   /* Sort out the arguments for the schedule entry. */
-  g_auto(GVariantDict) dict;
-  g_variant_dict_init (&dict, NULL);
+  g_auto(GVariantDict) dict = G_VARIANT_DICT_INIT (NULL);
   g_variant_dict_insert (&dict, "Priority", "u", priority);
   g_variant_dict_insert (&dict, "Resumable", "b", resumable);
   data->parameters = g_variant_ref_sink (g_variant_dict_end (&dict));

--- a/mogwai-schedule-client/meson.build
+++ b/mogwai-schedule-client/meson.build
@@ -4,7 +4,7 @@ mogwai_schedule_client_sources = [
 
 mogwai_schedule_client_deps = [
   dependency('gio-2.0', version: '>= 2.44'),
-  dependency('glib-2.0', version: '>= 2.44'),
+  dependency('glib-2.0', version: '>= 2.50'),
   dependency('gobject-2.0', version: '>= 2.44'),
   dependency('libsoup-2.4', version: '>= 2.42'),
   libmogwai_schedule_client_dep,


### PR DESCRIPTION
G_VARIANT_DICT_INIT does already exist, but not in the API reference I
was using, and the compiler doesn’t suggest using it unless you already
pass a parameter to it.

This tidies up the code a little, but introduces no functional changes.

It bumps the glib-2.0 dependency of mogwai-schedule-client, but that
makes no functional difference since other parts of Mogwai already
depend on a higher version of GLib (2.54).

Signed-off-by: Philip Withnall <withnall@endlessm.com>