### PR TITLE
T20396 Add tests for mogwai-schedule-client

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -36,6 +36,19 @@ Description: Download Scheduler Tools
  .
  This package contains tools for controlling the download scheduler.
 
+Package: mogwai-schedule-tools-tests
+Section: misc
+Architecture: any
+Depends:
+ ${misc:Depends},
+ ${shlibs:Depends},
+Description: Download Scheduler Tools - tests
+ This package contains a download scheduler for saving bandwidth on metered
+ connections.
+ .
+ This package contains unit tests for the tools for controlling the download
+ scheduler.
+
 Package: libmogwai-helper-1-tests
 Section: misc
 Architecture: any

--- a/debian/mogwai-schedule-tools-tests.install
+++ b/debian/mogwai-schedule-tools-tests.install
@@ -1,0 +1,2 @@
+usr/lib/*/installed-tests/mogwai-schedule-client-1
+usr/share/installed-tests/mogwai-schedule-client-1

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -5,6 +5,7 @@ Depends:
  libmogwai-schedule-1-tests,
  libmogwai-schedule-client-0-tests,
  libmogwai-tariff-0-tests,
+ mogwai-schedule-tools-tests,
 
 Tests: mogwai-tariff
 Depends:

--- a/debian/tests/gnome-desktop-testing
+++ b/debian/tests/gnome-desktop-testing
@@ -26,4 +26,5 @@ exec gnome-desktop-testing-runner \
 	libmogwai-schedule-1 \
 	libmogwai-schedule-client-0 \
 	libmogwai-tariff-0 \
+	mogwai-schedule-client-1 \
 	--

--- a/mogwai-schedule-client/main.c
+++ b/mogwai-schedule-client/main.c
@@ -36,8 +36,6 @@
 #include <unistd.h>
 
 
-/* FIXME: Add tests for this client. */
-
 /* Exit statuses. */
 typedef enum
 {

--- a/mogwai-schedule-client/meson.build
+++ b/mogwai-schedule-client/meson.build
@@ -18,3 +18,5 @@ executable('mogwai-schedule-client-' + mogwai_scheduled_api_version,
 
 # Documentation
 install_man('docs/mogwai-schedule-client.8')
+
+subdir('tests')

--- a/mogwai-schedule-client/tests/client.c
+++ b/mogwai-schedule-client/tests/client.c
@@ -1,0 +1,244 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2018 Endless Mobile, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Authors:
+ *  - Philip Withnall <withnall@endlessm.com>
+ */
+
+#include "config.h"
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <gio/gio.h>
+#include <locale.h>
+
+
+typedef struct
+{
+  gchar *tmpdir;  /* (owned) */
+  GSubprocessLauncher *launcher;  /* (owned) */
+} Fixture;
+
+static void
+setup (Fixture       *fixture,
+       gconstpointer  test_data)
+{
+  g_autoptr(GError) error = NULL;
+
+  fixture->launcher = g_subprocess_launcher_new (G_SUBPROCESS_FLAGS_STDOUT_PIPE |
+                                                 G_SUBPROCESS_FLAGS_STDERR_PIPE);
+
+  const gchar * const empty_array[1] = { NULL, };
+  g_subprocess_launcher_set_environ (fixture->launcher, (gchar **) empty_array);
+
+  fixture->tmpdir = g_dir_make_tmp ("mogwai-schedule-client-tests-basic-XXXXXX", &error);
+  g_assert_no_error (error);
+  g_subprocess_launcher_set_cwd (fixture->launcher, fixture->tmpdir);
+}
+
+static void
+teardown (Fixture       *fixture,
+          gconstpointer  test_data)
+{
+  g_assert_cmpint (g_rmdir (fixture->tmpdir), ==, 0);
+  g_clear_pointer (&fixture->tmpdir, g_free);
+  g_clear_object (&fixture->launcher);
+}
+
+/* Block on @process completing, and assert that it was successful (zero exit
+ * status, some output on stdout, no output on stderr). */
+static void
+assert_client_success (GSubprocess *process,
+                       const gchar *tmpdir,
+                       gboolean     quiet)
+{
+  g_autofree gchar *stdout_text = NULL;
+  g_autofree gchar *stderr_text = NULL;
+  g_autoptr(GError) error = NULL;
+
+  /* Block on the subprocess completing. */
+  g_subprocess_communicate_utf8 (process, NULL, NULL, &stdout_text, &stderr_text, &error);
+  g_assert_no_error (error);
+
+  /* Check its output. */
+  g_assert_cmpint (g_subprocess_get_exit_status (process), ==, 0);
+  if (quiet)
+    g_assert_cmpstr (stdout_text, ==, "");
+  else
+    g_assert_cmpstr (stdout_text, !=, "");
+  g_assert_cmpstr (stderr_text, ==, "");
+
+  /* Check the file exists and is non-empty. */
+  g_autofree gchar *out_path = g_build_filename (tmpdir, "out", NULL);
+
+  GStatBuf stat_buf = { 0, };
+  g_assert_cmpint (g_stat (out_path, &stat_buf), ==, 0);
+  g_assert_true (stat_buf.st_mode & S_IFREG);
+  g_assert_cmpuint (stat_buf.st_size, >, 0);
+
+  /* Clean up. */
+  g_unlink (out_path);
+}
+
+/* Test that something is successfully outputted for --help. */
+static void
+test_client_help (Fixture       *fixture,
+                  gconstpointer  test_data)
+{
+  g_autoptr(GError) error = NULL;
+
+  g_autoptr(GSubprocess) process = NULL;
+  process = g_subprocess_launcher_spawn (fixture->launcher, &error,
+                                         "mogwai-schedule-client", "--help",
+                                         NULL);
+  g_assert_no_error (error);
+
+  g_autofree gchar *stdout_text = NULL;
+  g_autofree gchar *stderr_text = NULL;
+
+  g_subprocess_communicate_utf8 (process, NULL, NULL, &stdout_text, &stderr_text, &error);
+  g_assert_no_error (error);
+
+  g_assert_cmpint (g_subprocess_get_exit_status (process), ==, 0);
+  g_assert_cmpstr (stdout_text, !=, "");
+  g_assert_cmpstr (stderr_text, ==, "");
+}
+
+/* Test error handling of various invalid command lines. */
+static void
+test_client_error_handling (Fixture       *fixture,
+                            gconstpointer  test_data)
+{
+  const gchar * const vectors[][6] =
+    {
+      { "mogwai-schedule-client", NULL, },
+      { "mogwai-schedule-client", "http://example.com/", NULL, },
+      { "mogwai-schedule-client", "too", "many", "arguments", NULL, },
+      { "mogwai-schedule-client", "-p", "not an int", "http://example.com/", "out", NULL, },
+      { "mogwai-schedule-client", "-p", "-1", "http://example.com/", "out", NULL, },
+      { "mogwai-schedule-client", "-p", "", "http://example.com/", "out", NULL, },
+    };
+
+  for (gsize i = 0; i < G_N_ELEMENTS (vectors); i++)
+    {
+      g_autoptr(GError) error = NULL;
+
+      g_test_message ("Vector %" G_GSIZE_FORMAT, i);
+
+      g_autoptr(GSubprocess) process = NULL;
+      process = g_subprocess_launcher_spawnv (fixture->launcher, vectors[i], &error);
+      g_assert_no_error (error);
+
+      g_autofree gchar *stdout_text = NULL;
+      g_autofree gchar *stderr_text = NULL;
+
+      g_subprocess_communicate_utf8 (process, NULL, NULL, &stdout_text, &stderr_text, &error);
+      g_assert_no_error (error);
+
+      g_assert_cmpint (g_subprocess_get_exit_status (process), ==, 1  /* invalid option */);
+      g_assert_cmpstr (stdout_text, ==, "");
+      g_assert_cmpstr (stderr_text, !=, "");
+    }
+}
+
+/* Test that a failed connection to D-Bus is correctly reported. */
+static void
+test_client_invalid_bus (Fixture       *fixture,
+                         gconstpointer  test_data)
+{
+  g_autoptr(GError) error = NULL;
+
+  g_autoptr(GSubprocess) process = NULL;
+  process = g_subprocess_launcher_spawn (fixture->launcher, &error,
+                                         "mogwai-schedule-client",
+                                         "-a", "not a bus",
+                                         "http://example.com/", "out",
+                                         NULL);
+  g_assert_no_error (error);
+
+  g_autofree gchar *stdout_text = NULL;
+  g_autofree gchar *stderr_text = NULL;
+
+  g_subprocess_communicate_utf8 (process, NULL, NULL, &stdout_text, &stderr_text, &error);
+  g_assert_no_error (error);
+
+  g_assert_cmpint (g_subprocess_get_exit_status (process), ==, 2  /* couldn’t connect to bus */);
+  g_assert_cmpstr (stdout_text, ==, "");
+  g_assert_cmpstr (stderr_text, !=, "");
+}
+
+/* Test that something is downloaded with a simple test, and that status
+ * information is printed along the way (unless we pass --quiet). */
+static void
+test_client_simple (Fixture       *fixture,
+                    gconstpointer  test_data)
+{
+  g_autoptr(GError) error = NULL;
+  gboolean quiet = GPOINTER_TO_INT (test_data);
+
+  g_autoptr(GSubprocess) process = NULL;
+  process = g_subprocess_launcher_spawn (fixture->launcher, &error,
+                                         "mogwai-schedule-client",
+                                         "http://example.com/", "out",
+                                         quiet ? "--quiet" : NULL,
+                                         NULL);
+  g_assert_no_error (error);
+
+  assert_client_success (process, fixture->tmpdir, quiet);
+}
+
+/* Test that something is downloaded when passing all arguments to the client. */
+static void
+test_client_all_arguments (Fixture       *fixture,
+                           gconstpointer  test_data)
+{
+  g_autoptr(GError) error = NULL;
+
+  g_autoptr(GSubprocess) process = NULL;
+  process = g_subprocess_launcher_spawn (fixture->launcher, &error,
+                                         "mogwai-schedule-client",
+                                         "--priority", "5",
+                                         "--resumable",
+                                         "http://example.com/", "out",
+                                         NULL);
+  g_assert_no_error (error);
+
+  assert_client_success (process, fixture->tmpdir, FALSE  /* not quiet */);
+}
+
+int
+main (int    argc,
+      char **argv)
+{
+  setlocale (LC_ALL, "");
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add ("/client/help", Fixture, NULL, setup, test_client_help, teardown);
+  g_test_add ("/client/error-handling", Fixture, NULL,
+              setup, test_client_error_handling, teardown);
+  g_test_add ("/client/invalid-bus", Fixture, NULL,
+              setup, test_client_invalid_bus, teardown);
+  g_test_add ("/client/simple", Fixture, GINT_TO_POINTER (FALSE)  /* !quiet */,
+              setup, test_client_simple, teardown);
+  g_test_add ("/client/simple/quiet", Fixture, GINT_TO_POINTER (TRUE)  /* quiet */,
+              setup, test_client_simple, teardown);
+  g_test_add ("/client/all-arguments", Fixture, NULL,
+              setup, test_client_all_arguments, teardown);
+
+  return g_test_run ();
+}

--- a/mogwai-schedule-client/tests/meson.build
+++ b/mogwai-schedule-client/tests/meson.build
@@ -1,0 +1,54 @@
+deps = [
+  dependency('gio-2.0', version: '>= 2.44'),
+  dependency('glib-2.0', version: '>= 2.44'),
+  dependency('gobject-2.0', version: '>= 2.44'),
+]
+
+envs = [
+  'G_TEST_SRCDIR=' + meson.current_source_dir(),
+  'G_TEST_BUILDDIR=' + meson.current_build_dir(),
+  'G_DEBUG=gc-friendly',
+  'MALLOC_CHECK_=2',
+]
+
+test_programs = [
+  ['client', [], deps, false],
+]
+
+installed_tests_metadir = join_paths(datadir, 'installed-tests',
+                                     'mogwai-schedule-client-' + mogwai_scheduled_api_version)
+installed_tests_execdir = join_paths(libexecdir, 'installed-tests',
+                                     'mogwai-schedule-client-' + mogwai_scheduled_api_version)
+
+foreach program: test_programs
+  test_conf = configuration_data()
+  test_conf.set('installed_tests_dir', installed_tests_execdir)
+  test_conf.set('program', program[0])
+
+  configure_file(
+    input: test_template,
+    output: program[0] + '.test',
+    install: enable_installed_tests,
+    install_dir: installed_tests_metadir,
+    configuration: test_conf,
+  )
+
+  exe = executable(
+    program[0],
+    [program[0] + '.c'] + program[1],
+    dependencies: program[2],
+    include_directories: root_inc,
+    install: enable_installed_tests,
+    install_dir: installed_tests_execdir,
+  )
+
+  # Only let Meson know about the tests which can be run in the builddir
+  # The client test, for example, is installed-only.
+  if program[3]
+    test(
+      program[0],
+      exe,
+      env: envs,
+    )
+  endif
+endforeach


### PR DESCRIPTION
These ensure the client behaves itself, but since they require the daemon to be running, they also act as simple tests for the daemon.

For the moment I have decided to punt on the question of what happens if the daemon refuses download permission to the test tool. These tests will currently fail if the daemon does refuse permission.

As the tests require the daemon to be running, they can only be run when installed (using `gnome-desktop-testing-runner`), and hence are excluded from the set of tests known to Meson.

https://phabricator.endlessm.com/T20396