### PR TITLE
libmogwai-tariff: Ensure tariff bytes are even more aligned

### DIFF
--- a/libmogwai-tariff/meson.build
+++ b/libmogwai-tariff/meson.build
@@ -58,4 +58,8 @@ pkgconfig.generate(
   requires: [ 'gio-2.0', 'glib-2.0', 'gobject-2.0' ],
 )
 
+if not cc.has_function('posix_memalign')
+  error('posix_memalign() function not found')
+endif
+
 subdir('tests')


### PR DESCRIPTION
It seems that the tariff data needs to be 8-aligned rather than
pointer-aligned in order to satisfy the alignment requirements of a
GVariant of type (sqv). (See
https://wiki.gnome.org/Projects/GLib/GVariant/Serialisation.)

Use posix_memalign() to that end.

Ideally, this is something which GLib would do internally for us; see
https://bugzilla.gnome.org/show_bug.cgi?id=793394.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T20396