### PR TITLE
debian: Make -dev packages depend on the corresponding binary packages

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -92,6 +92,7 @@ Architecture: any
 Multi-arch: same
 Depends:
  libglib2.0-dev,
+ libmogwai-schedule-client-0 (= ${binary:Version}),
  ${misc:Depends},
 Description: Download Scheduler Daemon - scheduler client library development
  This package contains a download scheduler for saving bandwidth on metered
@@ -131,6 +132,7 @@ Architecture: any
 Multi-arch: same
 Depends:
  libglib2.0-dev,
+ libmogwai-tariff-0 (= ${binary:Version}),
  ${misc:Depends},
 Description: Download Scheduler Daemon - tariff library development
  This package contains a download scheduler for saving bandwidth on metered


### PR DESCRIPTION
Otherwise they are fairly useless.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T20396

---

As suggested by @wjt on https://github.com/endlessm/eos-updater/pull/168#discussion_r167940612.