### PR TITLE
debian: Make mogwai-schedule-tools depend on mogwai-scheduled

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,6 +28,7 @@ Section: misc
 Architecture: any
 Multi-arch: same
 Depends:
+ mogwai-scheduled,
  ${misc:Depends},
  ${shlibs:Depends},
 Description: Download Scheduler Tools


### PR DESCRIPTION
Without the daemon to interact with, the scheduling client is fairly
useless.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T20396