### PR TITLE
debian: Set LC_ALL=C.UTF-8 when building

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -2,6 +2,7 @@
 # -*- makefile -*-
 
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export LC_ALL=C.UTF-8
 
 override_dh_auto_configure:
 	dh_auto_configure \


### PR DESCRIPTION
In order to handle UTF-8 output from tests, Meson needs to be running in
a UTF-8-capable environment. Set LC_ALL=C.UTF-8 for the entire build
process, which should achieve that.

Eventually, it looks like dpkg-buildpackage will set LC_ALL=C.UTF-8 by
default for all packages; when we depend on a version of
dpkg-buildpackage which does that, we can drop this change.

https://lists.debian.org/debian-devel/2017/09/msg00070.html

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T20743