### PR TITLE
T21783

### DIFF
--- a/libmogwai-schedule/scheduler-interface.h
+++ b/libmogwai-schedule/scheduler-interface.h
@@ -75,13 +75,38 @@ static const GDBusMethodInfo *scheduler_interface_methods[] =
   NULL,
 };
 
+static const GDBusPropertyInfo scheduler_interface_entry_count =
+{
+  -1, /* ref count */
+  "EntryCount",
+  "u",
+  G_DBUS_PROPERTY_INFO_FLAGS_READABLE,
+  NULL,  /* annotations */
+};
+
+static const GDBusPropertyInfo scheduler_interface_active_entry_count =
+{
+  -1, /* ref count */
+  "ActiveEntryCount",
+  "u",
+  G_DBUS_PROPERTY_INFO_FLAGS_READABLE,
+  NULL,  /* annotations */
+};
+
+static const GDBusPropertyInfo *scheduler_interface_properties[] =
+{
+  &scheduler_interface_entry_count,
+  &scheduler_interface_active_entry_count,
+  NULL,
+};
+
 static const GDBusInterfaceInfo scheduler_interface =
 {
   -1,  /* ref count */
   (gchar *) "com.endlessm.DownloadManager1.Scheduler",
   (GDBusMethodInfo **) scheduler_interface_methods,
   NULL,  /* no signals */
-  NULL,  /* no properties */
+  (GDBusPropertyInfo **) scheduler_interface_properties,
   NULL,  /* no annotations */
 };
 


### PR DESCRIPTION
At this point, this is not ready yet to merge. I'm opening this PR to gather enough feedback on what was done.

Things that need special attention:

 * ~~The naming sounds a bit off to me (e.g. Mogwai deals with "entries not "updates", thus "QueuedUpdates" doesn't really match the internal naming) but it makes sense for the purposes of them~~ ✓
 * ~~The patches make `MwsScheduleEntry` store and expose the `download-now` field. This is used as an indicator for the new `Downloading` property, but at this level of the stack, we cannot know if the download is actually happening - only that it **can** happen~~ ✓
 * ~~What about implementing those new properties in `MwsScheduler`?~~ ✓

https://phabricator.endlessm.com/T21783