### PR TITLE
libmogwai-schedule-client: Add missing gio header

### DIFF
--- a/libmogwai-schedule-client/schedule-entry.h
+++ b/libmogwai-schedule-client/schedule-entry.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <gio/gio.h>
 #include <glib.h>
 #include <glib-object.h>
 

--- a/libmogwai-schedule-client/scheduler.h
+++ b/libmogwai-schedule-client/scheduler.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <gio/gio.h>
 #include <glib.h>
 #include <glib-object.h>
 #include <libmogwai-schedule-client/schedule-entry.h>


### PR DESCRIPTION
We are using symbols from the gio header but not including the header.
So if a client tries to use the lib, they'll either have to add the
header themselves or it won't compile.