### PR TITLE
T21500 Fix timezone round trips for tariffs

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends:
  debhelper (>= 10),
  dh-python,
  dh-systemd,
- libglib2.0-dev (>= 2.54.2-1endless2),
+ libglib2.0-dev (>= 2.54.2-1endless3),
  libnm-dev (>= 1.8.0),
  libsoup2.4-dev (>= 2.42.0),
  libsystemd-dev,

--- a/libmogwai-schedule/scheduler.c
+++ b/libmogwai-schedule/scheduler.c
@@ -908,6 +908,9 @@ mws_scheduler_reschedule (MwsScheduler *self)
   g_autoptr(GDateTime) now = g_date_time_new_now_local ();
   g_autoptr(GDateTime) next_reschedule = NULL;
 
+  g_autofree gchar *now_str = g_date_time_format (now, "%FT%T%:::z");
+  g_debug ("%s: Considering now = %s", G_STRFUNC, now_str);
+
   /* For each entry, see if it’s permissible to start downloading it. For the
    * moment, we only use whether the network is metered as a basis for this
    * calculation. In future, we can factor in the tariff on each connection,
@@ -956,6 +959,21 @@ mws_scheduler_reschedule (MwsScheduler *self)
           if (details->tariff != NULL)
             {
               tariff_period = mwt_tariff_lookup_period (details->tariff, now);
+            }
+
+          if (tariff_period != NULL)
+            {
+              g_autofree gchar *tariff_period_start_str =
+                  g_date_time_format (mwt_period_get_start (tariff_period), "%FT%T%:::z");
+              g_autofree gchar *tariff_period_end_str =
+                  g_date_time_format (mwt_period_get_end (tariff_period), "%FT%T%:::z");
+              g_debug ("%s: Considering tariff period %p: %s to %s",
+                       G_STRFUNC, tariff_period, tariff_period_start_str,
+                       tariff_period_end_str);
+            }
+          else
+            {
+              g_debug ("%s: No tariff period found", G_STRFUNC);
             }
 
           if (tariff_period != NULL)

--- a/libmogwai-tariff/tariff-builder.c
+++ b/libmogwai-tariff/tariff-builder.c
@@ -246,17 +246,17 @@ mwt_tariff_builder_build_tariff_variant (const gchar *name,
     {
       MwtPeriod *period = g_ptr_array_index (periods, i);
       GDateTime *start = mwt_period_get_start (period);
+      GTimeZone *start_tz = g_date_time_get_timezone (start);
       GDateTime *end = mwt_period_get_end (period);
+      GTimeZone *end_tz = g_date_time_get_timezone (end);
       guint64 start_unix = g_date_time_to_unix (start);
       guint64 end_unix = g_date_time_to_unix (end);
-      const gchar *start_timezone = g_date_time_get_timezone_abbreviation (start);
-      const gchar *end_timezone = g_date_time_get_timezone_abbreviation (end);
 
       g_variant_builder_open (&builder, G_VARIANT_TYPE ("(ttssqut)"));
       g_variant_builder_add (&builder, "t", start_unix);
       g_variant_builder_add (&builder, "t", end_unix);
-      g_variant_builder_add (&builder, "s", start_timezone);
-      g_variant_builder_add (&builder, "s", end_timezone);
+      g_variant_builder_add (&builder, "s", g_time_zone_get_identifier (start_tz));
+      g_variant_builder_add (&builder, "s", g_time_zone_get_identifier (end_tz));
       g_variant_builder_add (&builder, "q", (guint16) mwt_period_get_repeat_type (period));
       g_variant_builder_add (&builder, "u", (guint32) mwt_period_get_repeat_period (period));
       g_variant_builder_add (&builder, "t", mwt_period_get_capacity_limit (period));

--- a/libmogwai-tariff/tests/common.c
+++ b/libmogwai-tariff/tests/common.c
@@ -1,0 +1,53 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2018 Endless Mobile, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Authors:
+ *  - Philip Withnall <withnall@endlessm.com>
+ */
+
+#include "config.h"
+
+#include <glib.h>
+#include <libmogwai-tariff/period.h>
+
+#include "common.h"
+
+
+void
+assert_periods_equal (MwtPeriod *period1,
+                      MwtPeriod *period2)
+{
+  g_assert_true (MWT_IS_PERIOD (period1));
+  g_assert_true (MWT_IS_PERIOD (period2));
+
+  GDateTime *period1_start = mwt_period_get_start (period1);
+  GDateTime *period1_end = mwt_period_get_end (period1);
+  GDateTime *period2_start = mwt_period_get_start (period2);
+  GDateTime *period2_end = mwt_period_get_end (period2);
+
+  g_assert_true (g_date_time_equal (period1_start, period2_start));
+  g_assert_true (g_date_time_equal (period1_end, period2_end));
+
+  g_assert_cmpint (mwt_period_get_repeat_type (period1), ==,
+                   mwt_period_get_repeat_type (period2));
+  g_assert_cmpuint (mwt_period_get_repeat_period (period1), ==,
+                    mwt_period_get_repeat_period (period2));
+
+  g_assert_cmpuint (mwt_period_get_capacity_limit (period1), ==,
+                    mwt_period_get_capacity_limit (period2));
+}

--- a/libmogwai-tariff/tests/common.c
+++ b/libmogwai-tariff/tests/common.c
@@ -36,12 +36,20 @@ assert_periods_equal (MwtPeriod *period1,
   g_assert_true (MWT_IS_PERIOD (period2));
 
   GDateTime *period1_start = mwt_period_get_start (period1);
+  GTimeZone *period1_start_tz = g_date_time_get_timezone (period1_start);
   GDateTime *period1_end = mwt_period_get_end (period1);
+  GTimeZone *period1_end_tz = g_date_time_get_timezone (period1_end);
   GDateTime *period2_start = mwt_period_get_start (period2);
+  GTimeZone *period2_start_tz = g_date_time_get_timezone (period2_start);
   GDateTime *period2_end = mwt_period_get_end (period2);
+  GTimeZone *period2_end_tz = g_date_time_get_timezone (period2_end);
 
   g_assert_true (g_date_time_equal (period1_start, period2_start));
+  g_assert_cmpstr (g_time_zone_get_identifier (period1_start_tz), ==,
+                   g_time_zone_get_identifier (period2_start_tz));
   g_assert_true (g_date_time_equal (period1_end, period2_end));
+  g_assert_cmpstr (g_time_zone_get_identifier (period1_end_tz), ==,
+                   g_time_zone_get_identifier (period2_end_tz));
 
   g_assert_cmpint (mwt_period_get_repeat_type (period1), ==,
                    mwt_period_get_repeat_type (period2));

--- a/libmogwai-tariff/tests/common.h
+++ b/libmogwai-tariff/tests/common.h
@@ -1,0 +1,33 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2018 Endless Mobile, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Authors:
+ *  - Philip Withnall <withnall@endlessm.com>
+ */
+
+#pragma once
+
+#include <glib.h>
+#include <libmogwai-tariff/period.h>
+
+G_BEGIN_DECLS
+
+void assert_periods_equal (MwtPeriod *period1,
+                           MwtPeriod *period2);
+
+G_END_DECLS

--- a/libmogwai-tariff/tests/meson.build
+++ b/libmogwai-tariff/tests/meson.build
@@ -37,7 +37,7 @@ foreach program: test_programs
 
   exe = executable(
     program[0],
-    [program[0] + '.c'] + program[1],
+    [program[0] + '.c', 'common.c', 'common.h'] + program[1],
     dependencies: program[2],
     include_directories: root_inc,
     install: enable_installed_tests,

--- a/libmogwai-tariff/tests/tariff-builder.c
+++ b/libmogwai-tariff/tests/tariff-builder.c
@@ -27,31 +27,7 @@
 #include <libmogwai-tariff/tariff-builder.h>
 #include <locale.h>
 
-
-/* Utility methods. */
-static void
-assert_periods_equal (MwtPeriod *period1,
-                      MwtPeriod *period2)
-{
-  g_assert_true (MWT_IS_PERIOD (period1));
-  g_assert_true (MWT_IS_PERIOD (period2));
-
-  GDateTime *period1_start = mwt_period_get_start (period1);
-  GDateTime *period1_end = mwt_period_get_end (period1);
-  GDateTime *period2_start = mwt_period_get_start (period2);
-  GDateTime *period2_end = mwt_period_get_end (period2);
-
-  g_assert_true (g_date_time_equal (period1_start, period2_start));
-  g_assert_true (g_date_time_equal (period1_end, period2_end));
-
-  g_assert_cmpint (mwt_period_get_repeat_type (period1), ==,
-                   mwt_period_get_repeat_type (period2));
-  g_assert_cmpuint (mwt_period_get_repeat_period (period1), ==,
-                    mwt_period_get_repeat_period (period2));
-
-  g_assert_cmpuint (mwt_period_get_capacity_limit (period1), ==,
-                    mwt_period_get_capacity_limit (period2));
-}
+#include "common.h"
 
 /* Test resetting an empty tariff builder doesn’t crash. */
 static void


### PR DESCRIPTION
https://phabricator.endlessm.com/T21500

This depends on the GLib backports in https://github.com/endlessm/glib/pull/41 and https://github.com/endlessm/glib/pull/42.

I’ve tested it with the included unit test locally, but haven’t tested it on a full VM; I need updated GLib packages including the backport to be able to do that.