### PR TITLE
T22164 Add API to add multiple schedule entries at once

### DIFF
--- a/libmogwai-schedule-client/scheduler.c
+++ b/libmogwai-schedule-client/scheduler.c
@@ -76,10 +76,11 @@ G_STATIC_ASSERT (G_N_ELEMENTS (scheduler_error_map) == G_N_ELEMENTS (scheduler_e
 /**
  * MwscScheduler:
  *
- * A proxy for the scheduler in the D-Bus service. Currently, the only method
- * available on #MwscScheduler is mwsc_scheduler_schedule_async(), which should
- * be used to create new #MwscScheduleEntrys. See the documentation for that
- * class for information.
+ * A proxy for the scheduler in the D-Bus service. Currently, the only methods
+ * available on #MwscScheduler are mwsc_scheduler_schedule_async() and
+ * mws_scheduler_schedule_entries_async(), which should
+ * be used to create new #MwscScheduleEntrys. See the documentation for those
+ * methods for information.
  *
  * If the service goes away, #MwscScheduler::invalidated will be emitted, and
  * all future method calls on the object will return a
@@ -852,6 +853,191 @@ mwsc_scheduler_schedule_finish (MwscScheduler  *self,
   g_return_val_if_fail (MWSC_IS_SCHEDULER (self), NULL);
   g_return_val_if_fail (g_task_is_valid (result, self), NULL);
   g_return_val_if_fail (g_async_result_is_tagged (result, mwsc_scheduler_schedule_async), NULL);
+  g_return_val_if_fail (error == NULL || *error == NULL, NULL);
+
+  return g_task_propagate_pointer (G_TASK (result), error);
+}
+
+typedef struct
+{
+  gsize n_entries;
+  GPtrArray *entries;  /* (element-type MwscScheduleEntry) (owned) */
+} ScheduleEntriesData;
+
+static void
+schedule_entries_data_free (ScheduleEntriesData *data)
+{
+  g_clear_pointer (&data->entries, g_ptr_array_unref);
+  g_free (data);
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (ScheduleEntriesData, schedule_entries_data_free)
+
+static void schedule_entries_cb (GObject      *obj,
+                                 GAsyncResult *result,
+                                 gpointer      user_data);
+static void proxy_entries_cb    (GObject      *obj,
+                                 GAsyncResult *result,
+                                 gpointer      user_data);
+
+/**
+ * mwsc_scheduler_schedule_entries_async:
+ * @self: a #MwscScheduler
+ * @parameters: non-empty array of #GVariants of type `a{sv}` giving initial
+ *    parameters for each of the schedule entries
+ * @cancellable: (nullable): a #GCancellable, or %NULL
+ * @callback: callback to invoke on completion
+ * @user_data: user data to pass to @callback
+ *
+ * Create one or more new #MwscScheduleEntrys in the scheduler and return them.
+ * The entries will be created with the given initial @parameters (which may be
+ * %NULL to use the defaults). As soon as the entries are created, the scheduler
+ * may schedule them, which it will do by setting
+ * #MwscScheduleEntry:download-now to %TRUE on one or more of them.
+ *
+ * If any of the #GVariants in @parameters are floating, they are consumed.
+ *
+ * The following @parameters are currently supported:
+ *
+ *  * `resumable` (`b`): sets #MwscScheduleEntry:resumable
+ *  * `priority` (`u`): sets #MwscScheduleEntry:priority
+ *
+ * Since: 0.1.0
+ */
+void
+mwsc_scheduler_schedule_entries_async (MwscScheduler       *self,
+                                       GPtrArray           *parameters,
+                                       GCancellable        *cancellable,
+                                       GAsyncReadyCallback  callback,
+                                       gpointer             user_data)
+{
+  g_return_if_fail (MWSC_IS_SCHEDULER (self));
+  g_return_if_fail (parameters != NULL && parameters->len > 0);
+  g_return_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable));
+
+  g_autoptr(GTask) task = g_task_new (self, cancellable, callback, user_data);
+  g_task_set_source_tag (task, mwsc_scheduler_schedule_entries_async);
+
+  if (!check_invalidated (self, task))
+    return;
+
+  g_auto(GVariantBuilder) builder = G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE ("(aa{sv})"));
+  g_variant_builder_open (&builder, G_VARIANT_TYPE ("aa{sv}"));
+
+  for (gsize i = 0; i < parameters->len; i++)
+    {
+      GVariant *variant = g_ptr_array_index (parameters, i);
+
+      if (variant == NULL)
+        variant = g_variant_new ("a{sv}", NULL);
+
+      g_return_if_fail (g_variant_is_normal_form (variant) &&
+                        g_variant_is_of_type (variant, G_VARIANT_TYPE_VARDICT));
+
+      g_variant_builder_add_value (&builder, variant);
+    }
+
+  g_variant_builder_close (&builder);
+
+  g_dbus_proxy_call (self->proxy,
+                     "ScheduleEntries",
+                     g_variant_builder_end (&builder),
+                     G_DBUS_CALL_FLAGS_NONE,
+                     -1,  /* default timeout */
+                     cancellable,
+                     schedule_entries_cb,
+                     g_steal_pointer (&task));
+}
+
+static void
+schedule_entries_cb (GObject      *obj,
+                     GAsyncResult *result,
+                     gpointer      user_data)
+{
+  GDBusProxy *proxy = G_DBUS_PROXY (obj);
+  g_autoptr(GTask) task = G_TASK (user_data);
+  MwscScheduler *self = g_task_get_source_object (task);
+  GCancellable *cancellable = g_task_get_cancellable (task);
+  g_autoptr(GError) error = NULL;
+
+  /* Grab the schedule entries. */
+  g_autoptr(GVariant) return_value = NULL;
+  return_value = g_dbus_proxy_call_finish (proxy, result, &error);
+
+  if (error != NULL)
+    {
+      g_task_return_error (task, g_steal_pointer (&error));
+      return;
+    }
+
+  /* Start constructing the entries in parallel. */
+  g_autoptr(GVariantIter) iter = NULL;
+  const gchar *schedule_entry_path;
+  g_variant_get (return_value, "(ao)", &iter);
+
+  /* Set up the return closure. */
+  g_autoptr(ScheduleEntriesData) data = g_new0 (ScheduleEntriesData, 1);
+  data->n_entries = g_variant_iter_n_children (iter);
+  data->entries = g_ptr_array_new_with_free_func (g_object_unref);
+  g_task_set_task_data (task, g_steal_pointer (&data),
+                        (GDestroyNotify) schedule_entries_data_free);
+
+  while (g_variant_iter_loop (iter, "&o", &schedule_entry_path))
+    {
+      mwsc_schedule_entry_new_full_async (g_dbus_proxy_get_connection (self->proxy),
+                                          g_dbus_proxy_get_name (self->proxy),
+                                          schedule_entry_path,
+                                          cancellable,
+                                          proxy_entries_cb,
+                                          g_steal_pointer (&task));
+    }
+}
+
+static void
+proxy_entries_cb (GObject      *obj,
+                  GAsyncResult *result,
+                  gpointer      user_data)
+{
+  g_autoptr(GTask) task = G_TASK (user_data);
+  g_autoptr(GError) local_error = NULL;
+  ScheduleEntriesData *data = g_task_get_task_data (task);
+
+  g_autoptr(MwscScheduleEntry) entry = mwsc_schedule_entry_new_full_finish (result, &local_error);
+
+  if (entry == NULL)
+    {
+      g_task_return_error (task, g_steal_pointer (&local_error));
+      return;
+    }
+
+  g_ptr_array_add (data->entries, g_steal_pointer (&entry));
+
+  if (data->entries->len == data->n_entries && !g_task_had_error (task))
+    g_task_return_pointer (task, g_steal_pointer (&data->entries),
+                           (GDestroyNotify) g_ptr_array_unref);
+}
+
+/**
+ * mwsc_scheduler_schedule_entries_finish:
+ * @self: a #MwscScheduleEntry
+ * @result: asynchronous operation result
+ * @error: return location for a #GError
+ *
+ * Finish adding one or more #MwscScheduleEntrys. See
+ * mwsc_scheduler_schedule_entries_async().
+ *
+ * Returns: (transfer full) (element-type MwscScheduleEntry): an non-empty array
+ *    of the new #MwscScheduleEntrys
+ * Since: 0.1.0
+ */
+GPtrArray *
+mwsc_scheduler_schedule_entries_finish (MwscScheduler  *self,
+                                        GAsyncResult   *result,
+                                        GError        **error)
+{
+  g_return_val_if_fail (MWSC_IS_SCHEDULER (self), NULL);
+  g_return_val_if_fail (g_task_is_valid (result, self), NULL);
+  g_return_val_if_fail (g_async_result_is_tagged (result, mwsc_scheduler_schedule_entries_async), NULL);
   g_return_val_if_fail (error == NULL || *error == NULL, NULL);
 
   return g_task_propagate_pointer (G_TASK (result), error);

--- a/libmogwai-schedule-client/scheduler.h
+++ b/libmogwai-schedule-client/scheduler.h
@@ -84,4 +84,13 @@ MwscScheduleEntry *mwsc_scheduler_schedule_finish (MwscScheduler        *self,
                                                    GAsyncResult         *result,
                                                    GError              **error);
 
+void               mwsc_scheduler_schedule_entries_async  (MwscScheduler        *self,
+                                                           GPtrArray            *parameters,
+                                                           GCancellable         *cancellable,
+                                                           GAsyncReadyCallback   callback,
+                                                           gpointer              user_data);
+GPtrArray         *mwsc_scheduler_schedule_entries_finish (MwscScheduler        *self,
+                                                           GAsyncResult         *result,
+                                                           GError              **error);
+
 G_END_DECLS

--- a/libmogwai-schedule/peer-manager-dbus.c
+++ b/libmogwai-schedule/peer-manager-dbus.c
@@ -343,7 +343,7 @@ ensure_peer_credentials_cb (GObject      *obj,
   g_hash_table_replace (self->peer_credentials,
                         g_strdup (sender), g_strdup (sender_path));
 
-  g_task_return_pointer (task, g_strdup (sender_path), g_free);
+  g_task_return_pointer (task, g_steal_pointer (&sender_path), g_free);
 }
 
 static gchar *

--- a/libmogwai-schedule/schedule-entry-interface.h
+++ b/libmogwai-schedule/schedule-entry-interface.h
@@ -32,6 +32,7 @@ G_BEGIN_DECLS
  *
  * FIXME: Ideally, there would be a gdbus-codegen mode to generate just this
  * interface info, because writing it out in C is horrific.
+ * See: https://bugzilla.gnome.org/show_bug.cgi?id=795304
  */
 
 static const GDBusMethodInfo schedule_entry_interface_remove =

--- a/libmogwai-schedule/schedule-service.c
+++ b/libmogwai-schedule/schedule-service.c
@@ -1365,7 +1365,7 @@ schedule_cb (GObject      *obj,
   g_autoptr(GError) local_error = NULL;
 
   /* Finish looking up the sender. */
-  const gchar *sender_path = NULL;
+  g_autofree gchar *sender_path = NULL;
   sender_path = mws_peer_manager_ensure_peer_credentials_finish (peer_manager,
                                                                  result, &local_error);
 

--- a/libmogwai-schedule/schedule-service.c
+++ b/libmogwai-schedule/schedule-service.c
@@ -121,7 +121,7 @@ static void mws_schedule_service_scheduler_properties_get_all (MwsScheduleServic
                                                                const gchar           *sender,
                                                                GVariant              *parameters,
                                                                GDBusMethodInvocation *invocation);
-static void mws_schedule_service_scheduler_schedule           (MwsScheduleService    *self,
+static void mws_schedule_service_scheduler_schedule_entries   (MwsScheduleService    *self,
                                                                GDBusConnection       *connection,
                                                                const gchar           *sender,
                                                                GVariant              *parameters,
@@ -1124,7 +1124,9 @@ scheduler_methods[] =
 
     /* Scheduler methods. */
     { "com.endlessm.DownloadManager1.Scheduler", "Schedule",
-      mws_schedule_service_scheduler_schedule },
+      mws_schedule_service_scheduler_schedule_entries },
+    { "com.endlessm.DownloadManager1.Scheduler", "ScheduleEntries",
+      mws_schedule_service_scheduler_schedule_entries },
   };
 
 G_STATIC_ASSERT (G_N_ELEMENTS (scheduler_methods) ==
@@ -1256,18 +1258,18 @@ typedef struct
 {
   MwsScheduleService *schedule_service;  /* (unowned) */
   GDBusMethodInvocation *invocation;  /* (owned) */
-  MwsScheduleEntry *entry;  /* (owned) */
+  GPtrArray *entries;  /* (element-type MwsScheduleEntry) (owned) */
 } ScheduleData;
 
 static ScheduleData *
 schedule_data_new (MwsScheduleService    *schedule_service,
                    GDBusMethodInvocation *invocation,
-                   MwsScheduleEntry      *entry)
+                   GPtrArray             *entries)
 {
   ScheduleData *data = g_new0 (ScheduleData, 1);
   data->schedule_service = schedule_service;
   data->invocation = g_object_ref (invocation);
-  data->entry = g_object_ref (entry);
+  data->entries = g_ptr_array_ref (entries);
   return data;
 }
 
@@ -1275,7 +1277,7 @@ static void
 schedule_data_free (ScheduleData *data)
 {
   g_clear_object (&data->invocation);
-  g_clear_object (&data->entry);
+  g_clear_pointer (&data->entries, g_ptr_array_unref);
   g_free (data);
 }
 
@@ -1286,28 +1288,59 @@ static void schedule_cb (GObject      *obj,
                          gpointer      user_data);
 
 static void
-mws_schedule_service_scheduler_schedule (MwsScheduleService    *self,
-                                         GDBusConnection       *connection,
-                                         const gchar           *sender,
-                                         GVariant              *parameters,
-                                         GDBusMethodInvocation *invocation)
+mws_schedule_service_scheduler_schedule_entries (MwsScheduleService    *self,
+                                                 GDBusConnection       *connection,
+                                                 const gchar           *sender,
+                                                 GVariant              *parameters,
+                                                 GDBusMethodInvocation *invocation)
 {
   g_autoptr(GError) local_error = NULL;
 
-  /* Create a schedule entry, validating the parameters at the time. */
-  g_autoptr(GVariant) properties_variant = NULL;
-  g_variant_get (parameters, "(@a{sv})", &properties_variant);
+  /* This method implements both .Schedule and .ScheduleEntries, switching on
+   * the invoked method name to work out whether to handle one or several
+   * entries. */
+  g_autoptr(GPtrArray) entries = g_ptr_array_new_with_free_func (g_object_unref);
 
-  g_autoptr(MwsScheduleEntry) entry = NULL;
-  entry = mws_schedule_entry_new_from_variant (sender, properties_variant, &local_error);
-
-  if (entry == NULL)
+  /* Create one or more schedule entries, validating the parameters at the time. */
+  if (g_str_equal (g_dbus_method_invocation_get_method_name (invocation), "Schedule"))
     {
-      g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
-                                             G_DBUS_ERROR_INVALID_ARGS,
-                                             _("Invalid schedule entry parameters: %s"),
-                                             local_error->message);
-      return;
+      g_autoptr(GVariant) properties_variant = NULL;
+      g_variant_get (parameters, "(@a{sv})", &properties_variant);
+
+      g_ptr_array_add (entries, mws_schedule_entry_new_from_variant (sender, properties_variant, &local_error));
+
+      if (local_error != NULL)
+        {
+          g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
+                                                 G_DBUS_ERROR_INVALID_ARGS,
+                                                 _("Invalid schedule entry parameters: %s"),
+                                                 local_error->message);
+          return;
+        }
+    }
+  else if (g_str_equal (g_dbus_method_invocation_get_method_name (invocation), "ScheduleEntries"))
+    {
+      g_autoptr(GVariantIter) properties_array_iter = NULL;
+      g_variant_get (parameters, "(aa{sv})", &properties_array_iter);
+
+      g_autoptr(GVariant) properties_variant = NULL;
+      while (g_variant_iter_loop (properties_array_iter, "@a{sv}", &properties_variant))
+        {
+          g_ptr_array_add (entries, mws_schedule_entry_new_from_variant (sender, properties_variant, &local_error));
+
+          if (local_error != NULL)
+            {
+              g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
+                                                     G_DBUS_ERROR_INVALID_ARGS,
+                                                     _("Invalid schedule entry parameters: %s"),
+                                                     local_error->message);
+              return;
+            }
+        }
+    }
+  else
+    {
+      g_assert_not_reached ();
     }
 
   /* Load the peer’s credentials and watch to see if it disappears in future (to
@@ -1316,7 +1349,7 @@ mws_schedule_service_scheduler_schedule (MwsScheduleService    *self,
   mws_peer_manager_ensure_peer_credentials_async (mws_scheduler_get_peer_manager (self->scheduler),
                                                   sender, self->cancellable,
                                                   schedule_cb,
-                                                  schedule_data_new (self, invocation, entry));
+                                                  schedule_data_new (self, invocation, entries));
 }
 
 static void
@@ -1328,7 +1361,7 @@ schedule_cb (GObject      *obj,
   g_autoptr(ScheduleData) data = user_data;
   MwsScheduleService *self = data->schedule_service;
   GDBusMethodInvocation *invocation = data->invocation;
-  MwsScheduleEntry *entry = data->entry;
+  GPtrArray *entries = data->entries;  /* (element-type MwsScheduleEntry) */
   g_autoptr(GError) local_error = NULL;
 
   /* Finish looking up the sender. */
@@ -1343,11 +1376,8 @@ schedule_cb (GObject      *obj,
       return;
     }
 
-  /* Add it to the scheduler. */
-  g_autoptr(GPtrArray) added = g_ptr_array_new_with_free_func (NULL);
-  g_ptr_array_add (added, entry);
-
-  if (!mws_scheduler_update_entries (self->scheduler, added, NULL, &local_error))
+  /* Add the entries to the scheduler. */
+  if (!mws_scheduler_update_entries (self->scheduler, entries, NULL, &local_error))
     {
       /* We know this error domain is registered with #GDBusError. */
       g_warn_if_fail (local_error->domain == MWS_SCHEDULER_ERROR);
@@ -1356,10 +1386,34 @@ schedule_cb (GObject      *obj,
       return;
     }
 
-  /* Build a path for the entry and return it. */
-  g_autofree gchar *entry_path = schedule_entry_to_object_path (self, entry);
-  g_dbus_method_invocation_return_value (invocation,
-                                         g_variant_new ("(o)", entry_path));
+  /* Build paths for the entries and return them. */
+  if (g_str_equal (g_dbus_method_invocation_get_method_name (invocation), "Schedule"))
+    {
+      g_assert (entries->len == 1);
+      MwsScheduleEntry *entry = g_ptr_array_index (entries, 0);
+      g_autofree gchar *entry_path = schedule_entry_to_object_path (self, entry);
+      g_dbus_method_invocation_return_value (invocation,
+                                             g_variant_new ("(o)", entry_path));
+    }
+  else if (g_str_equal (g_dbus_method_invocation_get_method_name (invocation), "ScheduleEntries"))
+    {
+      g_auto(GVariantBuilder) builder = G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE ("(ao)"));
+      g_variant_builder_open (&builder, G_VARIANT_TYPE ("ao"));
+      for (gsize i = 0; i < entries->len; i++)
+        {
+          MwsScheduleEntry *entry = g_ptr_array_index (entries, i);
+          g_autofree gchar *entry_path = schedule_entry_to_object_path (self, entry);
+          g_variant_builder_add (&builder, "o", entry_path);
+        }
+      g_variant_builder_close (&builder);
+
+      g_dbus_method_invocation_return_value (invocation,
+                                             g_variant_builder_end (&builder));
+    }
+  else
+    {
+      g_assert_not_reached ();
+    }
 }
 
 /**

--- a/libmogwai-schedule/scheduler-interface.h
+++ b/libmogwai-schedule/scheduler-interface.h
@@ -70,9 +70,45 @@ static const GDBusMethodInfo scheduler_interface_schedule =
   NULL,  /* annotations */
 };
 
+static const GDBusArgInfo scheduler_interface_schedule_entries_arg_properties =
+{
+  -1,  /* ref count */
+  (gchar *) "properties",
+  (gchar *) "aa{sv}",
+  NULL
+};
+
+static const GDBusArgInfo scheduler_interface_schedule_entries_arg_entries =
+{
+  -1,  /* ref count */
+  (gchar *) "entry_array",
+  (gchar *) "ao",
+  NULL
+};
+
+static const GDBusArgInfo *scheduler_interface_schedule_entries_in_args[] =
+{
+  &scheduler_interface_schedule_entries_arg_properties,
+  NULL,
+};
+static const GDBusArgInfo *scheduler_interface_schedule_entries_out_args[] =
+{
+  &scheduler_interface_schedule_entries_arg_entries,
+  NULL,
+};
+static const GDBusMethodInfo scheduler_interface_schedule_entries =
+{
+  -1,  /* ref count */
+  (gchar *) "ScheduleEntries",
+  (GDBusArgInfo **) scheduler_interface_schedule_entries_in_args,
+  (GDBusArgInfo **) scheduler_interface_schedule_entries_out_args,
+  NULL,  /* annotations */
+};
+
 static const GDBusMethodInfo *scheduler_interface_methods[] =
 {
   &scheduler_interface_schedule,
+  &scheduler_interface_schedule_entries,
   NULL,
 };
 

--- a/libmogwai-schedule/scheduler-interface.h
+++ b/libmogwai-schedule/scheduler-interface.h
@@ -32,6 +32,7 @@ G_BEGIN_DECLS
  *
  * FIXME: Ideally, there would be a gdbus-codegen mode to generate just this
  * interface info, because writing it out in C is horrific.
+ * See: https://bugzilla.gnome.org/show_bug.cgi?id=795304
  */
 
 static const GDBusArgInfo scheduler_interface_schedule_arg_properties =

--- a/libmogwai-schedule/scheduler.c
+++ b/libmogwai-schedule/scheduler.c
@@ -564,7 +564,8 @@ mws_scheduler_update_entries (MwsScheduler  *self,
 
       g_debug ("Removing schedule entry ‘%s’.", entry_id);
 
-      /* FIXME: Upstream a g_hash_table_steal_extended() function which combines these two. */
+      /* FIXME: Upstream a g_hash_table_steal_extended() function which combines these two.
+       * See: https://bugzilla.gnome.org/show_bug.cgi?id=795302 */
       gpointer value;
       if (g_hash_table_lookup_extended (self->entries, entry_id, NULL, &value))
         {


### PR DESCRIPTION
**This is based on #43. That’s been reviewed and merged, so this can be reviewed now.**

https://phabricator.endlessm.com/T22164

Tests will come in a following PR, since I didn’t want to block review with them. I have tested this PR manually using `mogwai-schedule-client` on the command line — it at least works as well as the old API. I haven’t tested adding multiple entries yet.