### PR TITLE
build: Drop glib-2.0 subproject for building on Endless

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,8 +10,9 @@ project('mogwai','c',
 
 # Dependency on GLib. We depend on 2.57.1, which isn’t packaged yet. When it
 # is packaged in Debian Unstable, we can drop this subproject dependency (FIXME).
-libglib_dep = dependency('glib-2.0', version: '>= 2.57.1',
-                         fallback: ['glib-2.0', 'libglib_dep'])
+# FIXME: Endless’ GLib 2.54.2 has the necessary backported patches, so we drop
+# the subproject build to avoid ever accidentally using it.
+libglib_dep = dependency('glib-2.0', version: '>= 2.54.2')
 
 gnome = import('gnome')
 pkgconfig = import('pkgconfig')


### PR DESCRIPTION
Endless’ version of glib-2.0 has the right API backports in version
2.54.2 already, so we should never need to build glib-2.0 as a
subproject (unlike upstream Mogwai). So drop support for it so that we
never accidentally end up building it.

This is an Endless-specific patch, and can be dropped once upstream
Mogwai no longer uses a glib-2.0 subproject.

Signed-off-by: Philip Withnall <withnall@endlessm.com>