### PR TITLE
tests: Fix scheduler tests on 32-bit architectures

### DIFF
--- a/libmogwai-schedule/tests/scheduler.c
+++ b/libmogwai-schedule/tests/scheduler.c
@@ -941,7 +941,7 @@ test_scheduler_scheduling_tariff (Fixture       *fixture,
                                                          tariff1_period2_end,
                                                          MWT_PERIOD_REPEAT_DAY,
                                                          1,
-                                                         "capacity-limit", 0,
+                                                         "capacity-limit", G_GUINT64_CONSTANT (0),
                                                          NULL);
   g_ptr_array_add (tariff1_periods, tariff1_period2);
 
@@ -973,7 +973,7 @@ test_scheduler_scheduling_tariff (Fixture       *fixture,
                                                          tariff2_period1_end,
                                                          MWT_PERIOD_REPEAT_DAY,
                                                          1,
-                                                         "capacity-limit", 0,
+                                                         "capacity-limit", G_GUINT64_CONSTANT (0),
                                                          NULL);
   g_ptr_array_add (tariff2_periods, tariff2_period1);
 
@@ -998,7 +998,7 @@ test_scheduler_scheduling_tariff (Fixture       *fixture,
                                                          tariff3_period1_end,
                                                          MWT_PERIOD_REPEAT_NONE,
                                                          0,
-                                                         "capacity-limit", 0,
+                                                         "capacity-limit", G_GUINT64_CONSTANT (0),
                                                          NULL);
   g_ptr_array_add (tariff3_periods, tariff3_period1);
 


### PR DESCRIPTION
The scheduler tests pass a 64-bit vararg (capacity-limit) to
mwt_period_new(), but without explicit size indications, the compiler
will assume the constant is a normal integer. On 32-bit architectures
this means a 32-bit vararg is put in, and a 64-bit vararg is read out.
This gives erroneous results and was causing the scheduler tests to
fail.

Backport of upstream commit https://gitlab.freedesktop.org/pwithnall/mogwai/commit/5be551ca9a1ffc583e538d1a1c4c225e9246253f.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

---

https://phabricator.endlessm.com/T20423