### PR TITLE
build: Simplify pkg-config file generation

### DIFF
--- a/libmogwai-schedule-client/meson.build
+++ b/libmogwai-schedule-client/meson.build
@@ -9,7 +9,7 @@ libmogwai_schedule_client_headers = [
   'scheduler.h',
 ]
 
-libmogwai_schedule_client_deps = [
+libmogwai_schedule_client_public_deps = [
   dependency('gio-2.0', version: '>= 2.46'),
   libglib_dep,
   dependency('gobject-2.0', version: '>= 2.54'),
@@ -17,7 +17,7 @@ libmogwai_schedule_client_deps = [
 
 libmogwai_schedule_client = library(libmogwai_schedule_client_api_name,
   libmogwai_schedule_client_sources + libmogwai_schedule_client_headers,
-  dependencies: libmogwai_schedule_client_deps,
+  dependencies: libmogwai_schedule_client_public_deps,
   include_directories: root_inc,
   install: true,
   version: meson.project_version(),
@@ -40,8 +40,7 @@ pkgconfig.generate(
   name: 'libmogwai-schedule-client',
   filebase: libmogwai_schedule_client_api_name,
   description: 'Client library for download scheduling service.',
-  # FIXME: This should be derived from libmogwai_schedule_client_deps.
-  requires: [ 'gio-2.0', 'glib-2.0', 'gobject-2.0' ],
+  requires: libmogwai_schedule_client_public_deps,
 )
 
 subdir('tests')

--- a/libmogwai-tariff/meson.build
+++ b/libmogwai-tariff/meson.build
@@ -13,7 +13,7 @@ libmogwai_tariff_headers = [
   'tariff.h',
 ]
 
-libmogwai_tariff_deps = [
+libmogwai_tariff_public_deps = [
   dependency('gio-2.0', version: '>= 2.44'),
   libglib_dep,
   dependency('gobject-2.0', version: '>= 2.54'),
@@ -30,7 +30,7 @@ libmogwai_tariff_enums = gnome.mkenums_simple('enums',
 libmogwai_tariff = library(libmogwai_tariff_api_name,
   libmogwai_tariff_sources + libmogwai_tariff_headers,
   libmogwai_tariff_enums,
-  dependencies: libmogwai_tariff_deps,
+  dependencies: libmogwai_tariff_public_deps,
   include_directories: root_inc,
   install: true,
   version: meson.project_version(),
@@ -53,9 +53,7 @@ pkgconfig.generate(
   name: 'libmogwai-tariff',
   filebase: libmogwai_tariff_api_name,
   description: 'Library describing network connection tariffs.',
-  # FIXME: This should be derived from libmogwai_tariff_deps with Meson 0.45;
-  # see the `libraries` docs: http://mesonbuild.com/Pkgconfig-module.html#pkggenerate
-  requires: [ 'gio-2.0', 'glib-2.0', 'gobject-2.0' ],
+  requires: libmogwai_tariff_public_deps,
 )
 
 if not cc.has_function('posix_memalign')

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('mogwai','c',
   version: '0.1.0',
-  meson_version: '>= 0.43.0',
+  meson_version: '>= 0.45.0',
   license: 'LGPLv2.1+',
   default_options: [
     'c_std=gnu11',


### PR DESCRIPTION
Meson 0.45 can automatically build the Requires line from a list of
dependencies, rather than us having to maintain two separate lists.

This bumps our Meson dependency to 0.45.

Signed-off-by: Philip Withnall <withnall@endlessm.com>