### PR TITLE
T28086 Fix allow-downloads property when a VPN is enabled

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -47,3 +47,20 @@ $ # add Environment=G_MESSAGES_DEBUG=all
 $ sudo systemctl restart mogwai-scheduled.service
 $ sudo journalctl -b -u mogwai-scheduled.service
 ```
+
+Changing the settings on a connection
+---
+
+When debugging, it can sometimes be useful to forcibly change the metered data
+settings on a NetworkManager connection. This can be done by editing the
+connection’s configuration file in `/etc/NetworkManager/system-connections/`:
+add `connection.allow-downloads=0` or `connection.allow-downloads-when-metered=0`
+to it. Then run:
+```
+sudo nmcli connection down "${connection_name}"
+sudo nmcli connection up "${connection_name}"
+```
+
+You can check that Mogwai has detected the change by running
+`mogwai-schedule-client-1 monitor` as you do this; it will print a line saying
+that `allow-downloads` has changed.

--- a/libmogwai-schedule/scheduler.c
+++ b/libmogwai-schedule/scheduler.c
@@ -1001,7 +1001,7 @@ mws_scheduler_reschedule (MwsScheduler *self)
                           (GDestroyNotify) mws_connection_details_clear);
   g_array_set_size (all_connection_details, n_connections);
 
-  gboolean cached_allow_downloads = FALSE;
+  gboolean cached_allow_downloads = TRUE;
 
   for (gsize i = 0; all_connection_ids[i] != NULL; i++)
     {
@@ -1019,7 +1019,10 @@ mws_scheduler_reschedule (MwsScheduler *self)
           continue;
         }
 
-      cached_allow_downloads = cached_allow_downloads || out_details->allow_downloads;
+      /* FIXME: See FIXME below by `can_be_active` about allowing clients to
+       * specify whether they support downloading from selective connections.
+       * If that logic changes, so does this. */
+      cached_allow_downloads = cached_allow_downloads && out_details->allow_downloads;
     }
 
   if (self->cached_allow_downloads != cached_allow_downloads)

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('mogwai','c',
   version: '0.2.0',
-  meson_version: '>= 0.46.0',
+  meson_version: '>= 0.50.0',
   license: 'LGPLv2.1+',
   default_options: [
     'c_std=gnu11',


### PR DESCRIPTION
Trivial backport of the upstream fix, https://gitlab.freedesktop.org/pwithnall/mogwai/merge_requests/18. Fixed one small cherry-pick conflict in `meson.build`, trivially.

https://phabricator.endlessm.com/T28086