### PR TITLE
mogwai-schedule-client: port to libsoup-3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Dependencies
  * gio-2.0 ≥ 2.57.1
  * glib-2.0 ≥ 2.57.1
  * gobject-2.0 ≥ 2.57.1
- * libsoup-2.4 ≥ 2.42
+ * libsoup-3.0
  * systemd
 
 Licensing

--- a/mogwai-schedule-client/main.c
+++ b/mogwai-schedule-client/main.c
@@ -103,7 +103,6 @@ typedef struct
   gchar *uri;  /* (owned) */
   GFile *destination_file;  /* (owned) */
   SoupSession *session;  /* (owned) */
-  SoupRequest *request;  /* (owned) (nullable) */
   MwscScheduleEntry *entry;  /* (owned) (nullable) */
   gulong entry_notify_download_now_id;
   GInputStream *request_stream;  /* (owned) (nullable) */
@@ -116,7 +115,6 @@ download_data_free (DownloadData *data)
   g_clear_object (&data->request_stream);
   g_assert (data->entry_notify_download_now_id == 0);
   g_clear_object (&data->entry);
-  g_clear_object (&data->request);
   g_clear_object (&data->session);
   g_clear_object (&data->destination_file);
   g_clear_pointer (&data->uri, g_free);
@@ -137,9 +135,9 @@ static void entry_notify_download_now_cb (GObject    *obj,
                                           GParamSpec *pspec,
                                           gpointer    user_data);
 static void start_download (GTask *task);
-static void request_send_cb (GObject      *obj,
-                             GAsyncResult *result,
-                             gpointer      user_data);
+static void send_cb (GObject      *obj,
+                     GAsyncResult *result,
+                     gpointer      user_data);
 static void replace_cb (GObject      *obj,
                         GAsyncResult *result,
                         gpointer      user_data);
@@ -286,33 +284,34 @@ start_download (GTask *task)
 {
   DownloadData *data = g_task_get_task_data (task);
   GCancellable *cancellable = g_task_get_cancellable (task);
-  g_autoptr(GError) error = NULL;
+  SoupMessage *msg = NULL;
 
   /* Start the download. */
   g_message ("Starting download of ‘%s’", data->uri);
-  data->request = soup_session_request (data->session, data->uri, &error);
+  msg = soup_message_new (SOUP_METHOD_GET, data->uri);
 
-  if (error != NULL)
-    {
-      g_task_return_error (task, g_steal_pointer (&error));
-      return;
-    }
+  soup_session_send_async (data->session,
+                           msg,
+                           G_PRIORITY_DEFAULT,
+                           cancellable,
+                           send_cb,
+                           g_object_ref (task));
 
-  soup_request_send_async (data->request, cancellable, request_send_cb, g_object_ref (task));
+  g_object_unref (msg);
 }
 
 static void
-request_send_cb (GObject      *obj,
-                 GAsyncResult *result,
-                 gpointer      user_data)
+send_cb (GObject      *obj,
+         GAsyncResult *result,
+         gpointer      user_data)
 {
-  SoupRequest *request = SOUP_REQUEST (obj);
+  SoupSession *session = SOUP_SESSION (obj);
   g_autoptr(GTask) task = G_TASK (user_data);
   DownloadData *data = g_task_get_task_data (task);
   GCancellable *cancellable = g_task_get_cancellable (task);
   g_autoptr(GError) error = NULL;
 
-  data->request_stream = soup_request_send_finish (request, result, &error);
+  data->request_stream = soup_session_send_finish (session, result, &error);
 
   if (error != NULL)
     {

--- a/mogwai-schedule-client/meson.build
+++ b/mogwai-schedule-client/meson.build
@@ -6,7 +6,7 @@ mogwai_schedule_client_deps = [
   dependency('gio-2.0', version: '>= 2.44'),
   libglib_dep,
   dependency('gobject-2.0', version: '>= 2.44'),
-  dependency('libsoup-2.4', version: '>= 2.42'),
+  dependency('libsoup-3.0'),
   libmogwai_schedule_client_dep,
 ]
 


### PR DESCRIPTION
The main change is the removal of the SoupRequest object and using the
soup_session_send_async API directly on the SoupSession instead.

https://phabricator.endlessm.com/T33540