### PR TITLE
T33540 Rebase on 0.3.0 (packaging changes)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,7 @@ Standards-Version: 4.1.2
 Build-Depends:
  debhelper (>= 10),
  dh-python,
+ gtk-doc-tools,
  libglib2.0-dev (>= 2.54.2-1endless3),
  libnm-dev (>= 1.8.0),
  libsoup2.4-dev (>= 2.42.0),

--- a/debian/rules
+++ b/debian/rules
@@ -8,6 +8,7 @@ override_dh_auto_configure:
 	dh_auto_configure \
 		-- \
 		-Dinstalled_tests=true \
+		-Dsoup2=true \
 		$(NULL)
 
 # Don't start the services on install


### PR DESCRIPTION
Packaging changes to accompany https://github.com/endlessm/mogwai/pull/62.

The only real change is to force building against libsoup-2.4 rather than libsoup-3.0 as per T33540.

https://phabricator.endlessm.com/T33540