### PR TITLE
debian: Add libgsystemservice as a build-dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,7 @@ Build-Depends:
  dh-python,
  gtk-doc-tools,
  libglib2.0-dev (>= 2.54.2-1endless3),
+ libgsystemservice-0-dev (>= 0.1.0),
  libnm-dev (>= 1.8.0),
  libsoup2.4-dev (>= 2.42.0),
  libsystemd-dev,


### PR DESCRIPTION
This avoids trying to build it as a subproject, which fails on the OBS
builders as they don’t allow builds to have network access.

libgsystemservice is now packaged on EOS.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://phabricator.endlessm.com/T33540