### PR TITLE
debian: Add a systemd build-dep for access to systemd.pc

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,7 @@ Build-Depends:
  libsystemd-dev,
  meson,
  python3-dbusmock,
+ systemd,
 
 Package: mogwai-scheduled
 Section: misc


### PR DESCRIPTION
See https://gitlab.freedesktop.org/pwithnall/mogwai/-/merge_requests/26

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://phabricator.endlessm.com/T33540