### PR TITLE
Build against soup3

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Build-Depends:
  libglib2.0-dev (>= 2.57.1),
  libgsystemservice-0-dev (>= 0.1.0),
  libnm-dev (>= 1.8.0),
- libsoup2.4-dev (>= 2.42.0),
+ libsoup-3.0-dev,
  libsystemd-dev,
  meson,
  python3-dbusmock,

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends:
  debhelper (>= 10),
  dh-python,
  gtk-doc-tools,
- libglib2.0-dev (>= 2.54.2-1endless3),
+ libglib2.0-dev (>= 2.57.1),
  libgsystemservice-0-dev (>= 0.1.0),
  libnm-dev (>= 1.8.0),
  libsoup2.4-dev (>= 2.42.0),

--- a/debian/rules
+++ b/debian/rules
@@ -8,7 +8,6 @@ override_dh_auto_configure:
 	dh_auto_configure \
 		-- \
 		-Dinstalled_tests=true \
-		-Dsoup2=true \
 		$(NULL)
 
 # Don't start the services on install


### PR DESCRIPTION
Now that we have soup3 on master, we'd like to use it. While here, change the glib build dep back to its upstream specified value instead of relying on a particular downstream version.

https://phabricator.endlessm.com/T35073